### PR TITLE
Fix Policy Comparison Service Tests

### DIFF
--- a/ConditionalAccessExporter/Services/PolicyComparisonService.cs
+++ b/ConditionalAccessExporter/Services/PolicyComparisonService.cs
@@ -286,7 +286,7 @@ namespace ConditionalAccessExporter.Services
                 // Compare the policies
                 var diff = _jsonDiffPatch.Diff(matchingReference.Policy, entraPolicy);
                 
-                if (diff == null)
+                if (diff == null || diff.Type == JTokenType.Object && !diff.HasValues)
                 {
                     comparison.Status = ComparisonStatus.Identical;
                 }


### PR DESCRIPTION
Fixes #45

## Changes
- Updated PolicyComparisonService to properly handle empty JObjects during comparison
- Fixed issue where JsonDiffPatch returns empty JObject instead of null for identical policies
- This resolves all four failing tests:
  - CompareAsync_MultipleDifferenceTypes_ShouldReportCorrectly
  - CompareAsync_IdenticalPolicies_ShouldReportAsIdentical
  - CompareAsync_ReferenceDirectoryWithMalformedJson_ShouldSkipMalformedFiles
  - CompareAsync_ReferenceDirectoryWithNonJsonFiles_ShouldIgnoreNonJsonFiles

## Root Cause
The issue was in the `CompareEntraPolicyAsync` method where it only checked if the diff was null to determine identical policies. However, JsonDiffPatch sometimes returns an empty JObject (not null) when policies are identical, causing the service to incorrectly mark identical policies as different.