### PR TITLE
Fix Cross Format Report Generation Service

### DIFF
--- a/ConditionalAccessExporter/Services/CrossFormatReportGenerationService.cs
+++ b/ConditionalAccessExporter/Services/CrossFormatReportGenerationService.cs
@@ -8,6 +8,12 @@ namespace ConditionalAccessExporter.Services
     {
         public async Task<string> GenerateReportAsync(CrossFormatComparisonResult comparisonResult, string outputPath, ReportFormat format = ReportFormat.Json)
         {
+            // Ensure the output directory exists
+            if (!Directory.Exists(outputPath))
+            {
+                Directory.CreateDirectory(outputPath);
+            }
+            
             switch (format)
             {
                 case ReportFormat.Json:
@@ -25,6 +31,12 @@ namespace ConditionalAccessExporter.Services
 
         private async Task<string> GenerateJsonReportAsync(CrossFormatComparisonResult comparisonResult, string outputPath)
         {
+            // Ensure the output directory exists
+            if (!Directory.Exists(outputPath))
+            {
+                Directory.CreateDirectory(outputPath);
+            }
+            
             var fileName = Path.Combine(outputPath, $"cross-format-comparison-{DateTime.UtcNow:yyyyMMdd-HHmmss}.json");
             
             var jsonSettings = new JsonSerializerSettings
@@ -43,6 +55,12 @@ namespace ConditionalAccessExporter.Services
 
         private async Task<string> GenerateHtmlReportAsync(CrossFormatComparisonResult comparisonResult, string outputPath)
         {
+            // Ensure the output directory exists
+            if (!Directory.Exists(outputPath))
+            {
+                Directory.CreateDirectory(outputPath);
+            }
+            
             var fileName = Path.Combine(outputPath, $"cross-format-comparison-{DateTime.UtcNow:yyyyMMdd-HHmmss}.html");
             
             var html = GenerateHtmlContent(comparisonResult);
@@ -55,6 +73,12 @@ namespace ConditionalAccessExporter.Services
 
         private async Task<string> GenerateMarkdownReportAsync(CrossFormatComparisonResult comparisonResult, string outputPath)
         {
+            // Ensure the output directory exists
+            if (!Directory.Exists(outputPath))
+            {
+                Directory.CreateDirectory(outputPath);
+            }
+            
             var fileName = Path.Combine(outputPath, $"cross-format-comparison-{DateTime.UtcNow:yyyyMMdd-HHmmss}.md");
             
             var markdown = GenerateMarkdownContent(comparisonResult);
@@ -67,6 +91,12 @@ namespace ConditionalAccessExporter.Services
 
         private async Task<string> GenerateCsvReportAsync(CrossFormatComparisonResult comparisonResult, string outputPath)
         {
+            // Ensure the output directory exists
+            if (!Directory.Exists(outputPath))
+            {
+                Directory.CreateDirectory(outputPath);
+            }
+            
             var fileName = Path.Combine(outputPath, $"cross-format-comparison-{DateTime.UtcNow:yyyyMMdd-HHmmss}.csv");
             
             var csv = GenerateCsvContent(comparisonResult);


### PR DESCRIPTION
This PR addresses issue #46 by adding directory existence checks to all report generation methods.

Changes made:
- Updated `GenerateReportAsync` method to ensure the output directory exists
- Updated `GenerateJsonReportAsync` method to ensure the output directory exists
- Updated `GenerateHtmlReportAsync` method to ensure the output directory exists
- Updated `GenerateMarkdownReportAsync` method to ensure the output directory exists
- Updated `GenerateCsvReportAsync` method to ensure the output directory exists

These changes fix the issue where DirectoryNotFoundException was thrown when generating reports to non-existent directories.

Fixes #46