### PR TITLE
Fix Issue #44: Resolve console output race condition in ReportGenerationService tests

### DIFF
--- a/ConditionalAccessExporter.Tests/ConsoleOutputTestCollection.cs
+++ b/ConditionalAccessExporter.Tests/ConsoleOutputTestCollection.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+namespace ConditionalAccessExporter.Tests
+{
+    /// <summary>
+    /// Collection definition to ensure tests that manipulate Console.Out run sequentially
+    /// to avoid race conditions in console output redirection.
+    /// </summary>
+    [CollectionDefinition("Console Output Tests", DisableParallelization = true)]
+    public class ConsoleOutputTestCollection
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+}

--- a/ConditionalAccessExporter.Tests/CrossFormatReportGenerationServiceTests.cs
+++ b/ConditionalAccessExporter.Tests/CrossFormatReportGenerationServiceTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 
 namespace ConditionalAccessExporter.Tests
 {
+    [Collection("Console Output Tests")]
     public class CrossFormatReportGenerationServiceTests : IDisposable
     {
         private readonly CrossFormatReportGenerationService _reportService;

--- a/ConditionalAccessExporter.Tests/ProgramTests.cs
+++ b/ConditionalAccessExporter.Tests/ProgramTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace ConditionalAccessExporter.Tests
 {
+    [Collection("Console Output Tests")]
     public class ProgramTests
     {
         /// <summary>

--- a/ConditionalAccessExporter.Tests/ReportGenerationServiceTests.cs
+++ b/ConditionalAccessExporter.Tests/ReportGenerationServiceTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 
 namespace ConditionalAccessExporter.Tests
 {
+    [Collection("Console Output Tests")]
     public class ReportGenerationServiceTests : IDisposable
     {
         private readonly ReportGenerationService _reportService;


### PR DESCRIPTION
## Summary

Fixes Issue #44 - ReportGenerationService console report not generating "Matching Policies: X" output

## Root Cause Analysis

The issue was not with the `ReportGenerationService.GenerateConsoleReport()` method itself, but with race conditions in the test suite. Multiple test classes (`ReportGenerationServiceTests`, `CrossFormatReportGenerationServiceTests`, and `ProgramTests`) were manipulating `Console.Out` concurrently when tests ran in parallel, causing console output redirection to interfere with each other.

The target test `GenerateConsoleReport_WithAllIdentical_ShouldShowAllIdentical` would pass when run individually but fail when run as part of the full test suite due to this concurrency issue.

## Solution

- **Added `ConsoleOutputTestCollection.cs`**: Created a test collection definition with `DisableParallelization = true` to ensure tests that manipulate console output run sequentially
- **Applied `[Collection("Console Output Tests")]` attribute** to:
  - `ReportGenerationServiceTests`
  - `CrossFormatReportGenerationServiceTests` 
  - `ProgramTests`

This ensures all tests that redirect `Console.Out` run in the same collection sequentially, eliminating race conditions.

## Testing

- ✅ `GenerateConsoleReport_WithAllIdentical_ShouldShowAllIdentical` now passes consistently
- ✅ All 29 ReportGenerationService tests pass reliably
- ✅ All CrossFormatReportGenerationService tests pass
- ✅ Verified the fix works across multiple test runs

## Technical Details

The `ReportGenerationService.GenerateConsoleReport()` method was working correctly and properly outputting "Matching Policies: X" format. The race condition occurred because:

1. Multiple test classes were using `Console.SetOut()` simultaneously
2. xUnit runs tests in parallel by default
3. Console redirection state was being corrupted between concurrent tests
4. Tests would occasionally capture output from other tests or lose their redirected output

This fix ensures thread-safe console testing while maintaining the performance benefits of parallel test execution for other test classes.

Fixes #44