### PR TITLE
Fix Console Output Assertion in ExportPoliciesAsync Test

### DIFF
--- a/ConditionalAccessExporter.Tests/ProgramTests.cs
+++ b/ConditionalAccessExporter.Tests/ProgramTests.cs
@@ -545,7 +545,7 @@ namespace ConditionalAccessExporter.Tests
             // Assert
             Assert.NotNull(capturedOutput);
             // Even if we get an exception, we should see some output about the export attempt
-            Assert.Contains("Exporting", capturedOutput, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Conditional Access Policy Exporter", capturedOutput, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

This PR fixes the failing unit test `ExportPoliciesAsync_Success_ReturnsZero` by updating the console output assertion to match what the application actually outputs.

## Problem

Issue #56 reported that the test was failing because it expected to find the text "Exporting" in the console output, but this text was never actually being printed by the export process.

**Expected:** Console output contains "Exporting"  
**Actual:** String "Exporting" not found in captured output

The actual console output from the export process is:
```
Conditional Access Policy Exporter
==================================
```

## Solution

Updated the test assertion from:
```csharp
Assert.Contains("Exporting", capturedOutput, StringComparison.OrdinalIgnoreCase);
```

To:
```csharp
Assert.Contains("Conditional Access Policy Exporter", capturedOutput, StringComparison.OrdinalIgnoreCase);
```

This approach aligns with the recommended solution from the issue description to "Update Test Expectation: Change the test to look for text that is actually being output".

## Testing

- ✅ The specific failing test now passes
- ✅ All 187 tests in the test suite continue to pass
- ✅ No other functionality was affected

## Files Changed

- `ConditionalAccessExporter.Tests/ProgramTests.cs` - Updated console output assertion

Fixes #56