### PR TITLE
Fix GitHub Actions deployment failure due to permission error

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -7,9 +7,18 @@ on:
     branches: [ main, master ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
 
     steps:
     - uses: actions/checkout@v3
@@ -52,6 +61,7 @@ jobs:
       if: success() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
       uses: JamesIves/github-pages-deploy-action@v4
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         folder: coveragereport
         branch: gh-pages
         clean: true


### PR DESCRIPTION
## Description
This PR fixes the GitHub Actions workflow deployment failure described in issue #64.

## Problem
The GitHub Actions workflow was failing during the deployment step with the following error:
```
remote: Permission to thefaftek-git/CA_Scanner.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/thefaftek-git/CA_Scanner.git/': The requested URL returned error: 403
```

## Solution
Added explicit permissions to the workflow to allow the GitHub Actions bot to:
- Write to repository contents (required for pushing to gh-pages branch)
- Deploy to GitHub Pages
- Use OIDC tokens for secure authentication

### Changes Made
1. **Added workflow-level permissions**:
   - `contents: read` - Basic repository access
   - `pages: write` - GitHub Pages deployment
   - `id-token: write` - OIDC token usage

2. **Added job-level permissions**:
   - `contents: write` - Required for pushing to gh-pages branch
   - `pages: write` - GitHub Pages deployment
   - `id-token: write` - OIDC token usage

3. **Enhanced GitHub Pages deployment configuration**:
   - Added explicit `token: ${{ secrets.GITHUB_TOKEN }}` parameter
   - Ensures the deployment action uses the properly scoped token

## Testing
The workflow should now have the necessary permissions to successfully deploy the coverage report to GitHub Pages without encountering the 403 permission error.

## Closes
Fixes #64

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update