### PR TITLE
Fix Issue #67: Add multiple output formats support for --formats parameter

### DIFF
--- a/ConditionalAccessExporter/Program.cs
+++ b/ConditionalAccessExporter/Program.cs
@@ -130,9 +130,10 @@ namespace ConditionalAccessExporter
             );
             var reportFormatsOption = new Option<string[]>(
                 name: "--formats",
-                description: "Report formats to generate",
+                description: "Report formats to generate (space or comma-separated)",
                 getDefaultValue: () => new[] { "console", "json", "html" }
             );
+            reportFormatsOption.AllowMultipleArgumentsPerToken = true;
             var matchingStrategyOption = new Option<MatchingStrategy>(
                 name: "--matching",
                 description: "Strategy for matching policies",
@@ -183,9 +184,10 @@ namespace ConditionalAccessExporter
             );
             var crossReportFormatsOption = new Option<string[]>(
                 name: "--formats",
-                description: "Report formats to generate",
+                description: "Report formats to generate (space or comma-separated)",
                 getDefaultValue: () => new[] { "console", "json", "html", "markdown" }
             );
+            crossReportFormatsOption.AllowMultipleArgumentsPerToken = true;
             var crossMatchingStrategyOption = new Option<string>(
                 name: "--matching",
                 description: "Strategy for matching policies (ByName, ById, SemanticSimilarity, CustomMapping)",
@@ -558,6 +560,25 @@ namespace ConditionalAccessExporter
                     return 1;
                 }
                 
+                // Handle comma-separated formats in addition to space-separated ones
+                var processedFormats = new List<string>();
+                foreach (var format in reportFormats)
+                {
+                    if (format.Contains(','))
+                    {
+                        // Split comma-separated values
+                        var splitFormats = format.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                            .Select(f => f.Trim())
+                            .Where(f => !string.IsNullOrEmpty(f));
+                        processedFormats.AddRange(splitFormats);
+                    }
+                    else
+                    {
+                        processedFormats.Add(format.Trim());
+                    }
+                }
+                reportFormats = processedFormats.ToArray();
+                
                 Console.WriteLine($"Reference directory: {referenceDirectory}");
                 
                 if (!string.IsNullOrEmpty(entraFile))
@@ -787,6 +808,25 @@ namespace ConditionalAccessExporter
                     Console.WriteLine("Error: Reference directory is required but was not provided.");
                     return 1;
                 }
+                
+                // Handle comma-separated formats in addition to space-separated ones
+                var processedFormats = new List<string>();
+                foreach (var format in reportFormats)
+                {
+                    if (format.Contains(','))
+                    {
+                        // Split comma-separated values
+                        var splitFormats = format.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                            .Select(f => f.Trim())
+                            .Where(f => !string.IsNullOrEmpty(f));
+                        processedFormats.AddRange(splitFormats);
+                    }
+                    else
+                    {
+                        processedFormats.Add(format.Trim());
+                    }
+                }
+                reportFormats = processedFormats.ToArray();
                 
                 Console.WriteLine($"Source directory: {sourceDirectory}");
                 Console.WriteLine($"Reference directory: {referenceDirectory}");


### PR DESCRIPTION
## Summary

This PR fixes Issue #67 by adding support for multiple output formats in a single command using both space-separated and comma-separated syntax for the `--formats` parameter.

## Changes Made

### Core Changes
- **Enhanced format option parsing**: Added `AllowMultipleArgumentsPerToken = true` to both `reportFormatsOption` and `crossReportFormatsOption` in Program.cs
- **Added comma-separated parsing logic**: Implemented custom format processing in both `ComparePoliciesAsync` and `CrossFormatComparePoliciesAsync` methods to handle comma-separated values
- **Maintained backward compatibility**: Existing space-separated format specifications continue to work unchanged

### Technical Implementation
- **Space-separated parsing**: Handled natively by System.CommandLine with `AllowMultipleArgumentsPerToken = true`
- **Comma-separated parsing**: Custom logic splits comma-separated values, trims whitespace, and filters empty entries
- **Format processing**: Both approaches result in the same processed format list for report generation

## Testing

### ✅ Verified functionality with multiple test scenarios:

**Space-separated formats** (existing functionality):
```bash
--formats console json html
```
- ✅ Generates console output, JSON file, and HTML file

**Comma-separated formats** (new functionality):
```bash
--formats "console,json,html"
```
- ✅ Generates console output, JSON file, and HTML file

**Cross-format compare with multiple formats**:
```bash
--formats "console,json,html,markdown"
```
- ✅ Generates all 4 report formats successfully

### Test Results
- ✅ Build succeeds with no errors
- ✅ Both compare and cross-compare commands work with multiple formats
- ✅ All report formats (console, json, html, markdown) generate correctly
- ✅ Backward compatibility maintained for existing usage patterns

## Fixes

Closes #67

## Format Examples

Users can now use either syntax:
- **Space-separated**: `--formats console json html`
- **Comma-separated**: `--formats "console,json,html"`
- **Mixed spacing**: `--formats "console, json, html"` (spaces after commas are handled)

Both approaches produce identical results, giving users flexibility in how they specify multiple output formats.
