### PR TITLE
Fix nullable reference type warnings (CS8600, CS8601, CS8602)

### DIFF
--- a/ConditionalAccessExporter.Tests/CrossFormatPolicyComparisonServiceSpecificMethodTests.cs
+++ b/ConditionalAccessExporter.Tests/CrossFormatPolicyComparisonServiceSpecificMethodTests.cs
@@ -269,7 +269,7 @@ namespace ConditionalAccessExporter.Tests
         {
             // Arrange
             var jsonPolicy = CreateStandardJsonPolicy();
-            jsonPolicy["Conditions"]["ClientAppTypes"] = new JArray("Browser", "MobileAppsAndDesktopClients");
+            jsonPolicy["Conditions"]!["ClientAppTypes"] = new JArray("Browser", "MobileAppsAndDesktopClients");
             var entraExport = new { Policies = new[] { jsonPolicy } };
 
             var terraformDirectory = CreateTerraformDirectoryWithClientAppTypes(new[] { "browser", "mobileAppsAndDesktopClients" });
@@ -469,7 +469,7 @@ resource ""azuread_conditional_access_policy"" ""test_policy"" {
         private JObject CreateJsonPolicyWithUsers(string[] users)
         {
             var policy = CreateStandardJsonPolicy();
-            policy["Conditions"]["Users"]["IncludeUsers"] = new JArray(users);
+            policy["Conditions"]!["Users"]!["IncludeUsers"] = new JArray(users);
             return policy;
         }
 

--- a/ConditionalAccessExporter.Tests/CrossFormatPolicyComparisonServiceTests.cs
+++ b/ConditionalAccessExporter.Tests/CrossFormatPolicyComparisonServiceTests.cs
@@ -455,13 +455,13 @@ namespace ConditionalAccessExporter.Tests
             };
         }
 
-        private JObject CreateJsonPolicyWithConditions(string id, string displayName, string state, string[] includeUsers = null)
+        private JObject CreateJsonPolicyWithConditions(string id, string displayName, string state, string[]? includeUsers = null)
         {
             var policy = CreateJsonPolicy(id, displayName, state);
             
             if (includeUsers != null)
             {
-                policy["Conditions"]["Users"]["IncludeUsers"] = new JArray(includeUsers);
+                policy["Conditions"]!["Users"]!["IncludeUsers"] = new JArray(includeUsers);
             }
 
             return policy;
@@ -492,7 +492,7 @@ namespace ConditionalAccessExporter.Tests
 }}";
         }
 
-        private string CreateTerraformPolicyWithConditions(string resourceName, string displayName, string state, string[] includeUsers = null)
+        private string CreateTerraformPolicyWithConditions(string resourceName, string displayName, string state, string[]? includeUsers = null)
         {
             var usersSection = includeUsers != null 
                 ? $@"include_users = [""{string.Join(@""", """, includeUsers)}""]"

--- a/ConditionalAccessExporter.Tests/ProgramTestHelper.cs
+++ b/ConditionalAccessExporter.Tests/ProgramTestHelper.cs
@@ -27,7 +27,7 @@ namespace ConditionalAccessExporter.Tests
         {
             var mainMethod = GetPrivateMethod("Main");
             
-            var result = await (Task<int>)mainMethod.Invoke(null, new object[] { args });
+            var result = await (Task<int>)mainMethod.Invoke(null, new object[] { args })!;
             return result;
         }
 
@@ -38,7 +38,7 @@ namespace ConditionalAccessExporter.Tests
         {
             var method = GetPrivateMethod("ExportPoliciesAsync");
             
-            var result = await (Task<int>)method.Invoke(null, new object[] { outputPath });
+            var result = await (Task<int>)method.Invoke(null, new object[] { outputPath })!;
             return result;
         }
 
@@ -53,7 +53,7 @@ namespace ConditionalAccessExporter.Tests
         {
             var method = GetPrivateMethod("ConvertTerraformAsync");
             
-            var result = await (Task<int>)method.Invoke(null, new object[] { inputPath, outputPath, validate, verbose });
+            var result = await (Task<int>)method.Invoke(null, new object[] { inputPath, outputPath, validate, verbose })!;
             return result;
         }
 
@@ -83,7 +83,7 @@ namespace ConditionalAccessExporter.Tests
                     generateModule,
                     includeComments,
                     providerVersion
-                });
+                })!;
             return result;
         }
 
@@ -103,7 +103,7 @@ namespace ConditionalAccessExporter.Tests
             
             var result = await (Task<int>)method.Invoke(
                 null, 
-                new object[] { 
+                new object?[] { 
                     referenceDirectory,
                     entraFile,
                     outputDirectory,
@@ -113,11 +113,11 @@ namespace ConditionalAccessExporter.Tests
                     explainValues,
                     false, // exitOnDifferences
                     null,  // maxDifferences
-                    new string[0], // failOn
-                    new string[0], // ignore
+                    Array.Empty<string>(), // failOn
+                    Array.Empty<string>(), // ignore
                     false, // quiet
                     false  // skipValidation
-                });
+                })!;
             return result;
         }
 
@@ -147,7 +147,7 @@ namespace ConditionalAccessExporter.Tests
                     caseSensitive,
                     enableSemantic,
                     similarityThreshold
-                });
+                })!;
             return result;
         }
 
@@ -158,7 +158,7 @@ namespace ConditionalAccessExporter.Tests
         {
             var method = GetPrivateMethod("FetchEntraPoliciesAsync");
             
-            var result = await (Task<ConditionalAccessPolicyCollectionResponse>)method.Invoke(null, null);
+            var result = await (Task<ConditionalAccessPolicyCollectionResponse>)method.Invoke(null, null)!;
             return result;
         }
 
@@ -169,7 +169,7 @@ namespace ConditionalAccessExporter.Tests
         {
             var method = GetPrivateMethod("HandleExceptionAsync");
             
-            await (Task)method.Invoke(null, new object[] { exception });
+            await (Task)method.Invoke(null, new object[] { exception })!;
         }
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace ConditionalAccessExporter.Tests
                 includeImpactAnalysis,
                 dryRun,
                 backup
-            });
+            })!;
             return result;
         }
 

--- a/ConditionalAccessExporter.Tests/TerraformParsingServiceTests.cs
+++ b/ConditionalAccessExporter.Tests/TerraformParsingServiceTests.cs
@@ -450,18 +450,18 @@ resource ""azuread_conditional_access_policy"" ""full_policy"" {
             Assert.NotNull(policy.Conditions.UserRiskLevels);
             
             // Verify applications
-            Assert.Contains("All", policy.Conditions.Applications.IncludeApplications);
-            Assert.Contains("excluded-app", policy.Conditions.Applications.ExcludeApplications);
+            Assert.Contains("All", policy.Conditions.Applications.IncludeApplications!);
+            Assert.Contains("excluded-app", policy.Conditions.Applications.ExcludeApplications!);
             
             // Verify users
-            Assert.Contains("All", policy.Conditions.Users.IncludeUsers);
-            Assert.Contains("admin-user", policy.Conditions.Users.ExcludeUsers);
+            Assert.Contains("All", policy.Conditions.Users.IncludeUsers!);
+            Assert.Contains("admin-user", policy.Conditions.Users.ExcludeUsers!);
             
             // Verify grant controls
             Assert.NotNull(policy.GrantControls);
             Assert.Equal("OR", policy.GrantControls.Operator);
-            Assert.Contains("mfa", policy.GrantControls.BuiltInControls);
-            Assert.Contains("compliantDevice", policy.GrantControls.BuiltInControls);
+            Assert.Contains("mfa", policy.GrantControls.BuiltInControls!);
+            Assert.Contains("compliantDevice", policy.GrantControls.BuiltInControls!);
         }
 
         [Fact]

--- a/ConditionalAccessExporter/Services/PolicyComparisonService.cs
+++ b/ConditionalAccessExporter/Services/PolicyComparisonService.cs
@@ -111,7 +111,7 @@ namespace ConditionalAccessExporter.Services
                 throw new ArgumentException("Input JSON string cannot be null or empty.", nameof(json));
             }
 
-            JToken parsedToken;
+            JToken? parsedToken;
             try
             {
                 parsedToken = JsonConvert.DeserializeObject<JToken>(json);

--- a/ConditionalAccessExporter/Services/TerraformParsingService.cs
+++ b/ConditionalAccessExporter/Services/TerraformParsingService.cs
@@ -246,11 +246,11 @@ namespace ConditionalAccessExporter.Services
                 // Use JObject properties directly instead of dynamic conversion
                 var displayNameToken = jObj["display_name"];
                 if (displayNameToken != null)
-                    policy.DisplayName = displayNameToken.ToString();
+                    policy.DisplayName = displayNameToken.ToString() ?? string.Empty;
                 
                 var stateToken = jObj["state"];
                 if (stateToken != null)
-                    policy.State = stateToken.ToString();
+                    policy.State = stateToken.ToString() ?? string.Empty;
 
                 // Parse conditions from state
                 var conditionsToken = jObj["conditions"];
@@ -284,7 +284,7 @@ namespace ConditionalAccessExporter.Services
                 {
                     var displayNameValue = displayNameProp.GetValue(dynAttributes);
                     if (displayNameValue != null)
-                        policy.DisplayName = displayNameValue.ToString();
+                        policy.DisplayName = displayNameValue.ToString() ?? string.Empty;
                 }
                 
                 var stateProp = dynAttributes?.GetType().GetProperty("state");
@@ -292,7 +292,7 @@ namespace ConditionalAccessExporter.Services
                 {
                     var stateValue = stateProp.GetValue(dynAttributes);
                     if (stateValue != null)
-                        policy.State = stateValue.ToString();
+                        policy.State = stateValue.ToString() ?? string.Empty;
                 }
 
                 // For now, we'll skip conditions/grant_controls for non-JObject types
@@ -637,7 +637,7 @@ namespace ConditionalAccessExporter.Services
             var result = new List<string>();
             foreach (var item in array)
             {
-                result.Add(item.ToString());
+                result.Add(item?.ToString() ?? string.Empty);
             }
             
             return result.Any() ? result : null;
@@ -654,7 +654,7 @@ namespace ConditionalAccessExporter.Services
                 foreach (var item in arrayToken.Children())
                 {
                     if (item != null)
-                        result.Add(item.ToString());
+                        result.Add(item.ToString() ?? string.Empty);
                 }
             }
             


### PR DESCRIPTION
## Description
This PR fixes all nullable reference type warnings (CS8600, CS8601, CS8602) identified in Issue #87.

## Changes Made

### Core Services
- **PolicyComparisonService.cs** (line 117): Changed `JToken parsedToken` to `JToken? parsedToken` to properly handle nullable JSON tokens
- **TerraformParsingService.cs** (multiple lines): Added null-coalescing operators (`?? string.Empty`) to `ToString()` calls to prevent null reference exceptions

### Test Files
- **ProgramTestHelper.cs**: 
  - Changed `object[]` to `object?[]` to allow null values in method parameter arrays
  - Added null-forgiving operators (`!`) to method invocation calls
- **CrossFormatPolicyComparisonServiceSpecificMethodTests.cs**: Added null-forgiving operators (`!`) for safe JObject property access
- **CrossFormatPolicyComparisonServiceTests.cs**: Added null-forgiving operators (`!`) for safe JObject property access  
- **TerraformParsingServiceTests.cs**: Added null-forgiving operators (`!`) to Assert.Contains calls for collection parameters

## Testing
- ✅ Build now completes with **0 warnings** and **0 errors**
- ✅ All **197 tests pass** successfully
- ✅ No functionality has been broken by these changes

## Before/After
- **Before**: 34 nullable reference warnings across multiple files
- **After**: 0 nullable reference warnings

Fixes #87