### PR TITLE
Fix date comparison issue in PolicyComparisonService

### DIFF
--- a/ConditionalAccessExporter.Tests/PolicyComparisonServiceDateTests.cs
+++ b/ConditionalAccessExporter.Tests/PolicyComparisonServiceDateTests.cs
@@ -1,0 +1,23 @@
+
+using Xunit;
+using ConditionalAccessExporter.Services;
+using System.Globalization;
+
+namespace ConditionalAccessExporter.Tests
+{
+    public class PolicyComparisonServiceDateTests
+    {
+        [Theory]
+        [InlineData("2024-01-01T12:00:00Z", "2024-01-01T13:00:00Z", true)] // Same date, different time
+        [InlineData("2024-01-01T12:00:00Z", "2024-01-02T12:00:00Z", false)] // Different dates
+        [InlineData("2024-01-01T12:00:00.000Z", "2024-01-01T12:00:00Z", true)] // Same date, different precision
+        [InlineData("MM/dd/yyyy HH:mm:ss", "dd/MM/yyyy HH:mm:ss", false)] // Different formats but same date
+        public void AreEquivalentDates_ShouldCompareOnlyDateParts(string dateStr1, string dateStr2, bool expectedResult)
+        {
+            var result = PolicyComparisonService.AreEquivalentDates(dateStr1, dateStr2);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+    }
+}

--- a/ConditionalAccessExporter/Services/PolicyComparisonService.cs
+++ b/ConditionalAccessExporter/Services/PolicyComparisonService.cs
@@ -536,20 +536,26 @@ namespace ConditionalAccessExporter.Services
             return false;
         }
 
-        private static bool AreEquivalentDates(string str1, string str2)
+        public static bool AreEquivalentDates(string str1, string str2)
         {
             // Use culture-invariant parsing with predefined date formats
-            bool date1Parsed = DateTime.TryParseExact(str1, DateFormats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var date1) ||
-                               DateTime.TryParse(str1, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out date1);
+            bool date1Parsed = DateTime.TryParseExact(str1, DateFormats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var date1) ||
+                               DateTime.TryParse(str1, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out date1);
             
             // Short-circuit if first string isn't a valid date
             if (!date1Parsed)
                 return false;
             
-            bool date2Parsed = DateTime.TryParseExact(str2, DateFormats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var date2) ||
-                               DateTime.TryParse(str2, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out date2);
+            bool date2Parsed = DateTime.TryParseExact(str2, DateFormats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var date2) ||
+                               DateTime.TryParse(str2, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out date2);
             
-            return date2Parsed && date1 == date2;
+            // Compare dates with time component ignored for better comparison accuracy
+            if (date1Parsed && date2Parsed)
+            {
+                return date1.Date == date2.Date; // Compare only the date part
+            }
+
+            return false;
         }
 
         private ReferencePolicy? FindMatchingReference(


### PR DESCRIPTION

This PR fixes an issue with date comparisons in the PolicyComparisonService. The changes include:

1. Modified `AreEquivalentDates` method to compare only the date part of DateTime objects, ignoring time components
2. Added `DateTimeStyles.AdjustToUniversal` for better timezone handling
3. Added unit tests to verify the behavior

The fix ensures that policies with dates at different times but on the same day are correctly identified as equivalent.
