### PR TITLE
Enforce test coverage threshold in CI/CD pipeline

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -52,6 +52,20 @@ jobs:
         reporttypes: 'HtmlInline_AzurePipelines;Cobertura;Badges'
         
     - name: Upload coverage report artifact
+
+
+    - name: Check coverage threshold
+      if: success()
+      run: |
+        COVERAGE=$(grep -oPm1 "(?<=<coverage line-rate=\")[^\"]+" coveragereport/Cobertura.xml)
+        if (( $(echo "$COVERAGE < 0.80" | bc -l) )); then
+          echo "Coverage is below threshold: $COVERAGE"
+          exit 1
+        else
+          echo "Coverage is above threshold: $COVERAGE"
+        fi
+
+
       if: success()
       uses: actions/upload-artifact@v4
       with:

--- a/ConditionalAccessExporter.Tests/ConditionalAccessExporter.Tests.csproj
+++ b/ConditionalAccessExporter.Tests/ConditionalAccessExporter.Tests.csproj
@@ -14,6 +14,11 @@
     <AnalysisMode>Recommended</AnalysisMode>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
+
+    <CoverletOutputFormat>json</CoverletOutputFormat>
+    <CoverletOutput>./TestResults/</CoverletOutput>
+    <CoverletMinimumCoverage>80</CoverletMinimumCoverage>
+
     <WarningsNotAsErrors />
     <CodeAnalysisRuleSet>../ConditionalAccessExporter/security.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>


### PR DESCRIPTION
This pull request enforces a minimum test coverage threshold of 80% in the CI/CD pipeline. It adds a step to check the coverage report and fail the build if the coverage is below the specified threshold.

Closes #123